### PR TITLE
Fix infinite loop on certain ICAPs

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,17 @@ ICAP.decodeBBAN = function (bban) {
     var tmp = hex.bytesToHex(bs36.decode(bban))
 
     // FIXME: horrible padding code
-    while (tmp.length !== 40) {
+    while (tmp.length < 40) {
       tmp = '0' + tmp
+    }
+
+    var extraZeroes = tmp.length - 40
+    if (extraZeroes > 0) {
+      var zeroes = tmp.slice(0, extraZeroes)
+      for (var i = 0; i < extraZeroes; i++) {
+        if (zeroes[i] !== '0') throw new Error('Not a valid Ethereum BBAN')
+      }
+      tmp = tmp.slice(extraZeroes)
     }
 
     return '0x' + tmp

--- a/test/index.js
+++ b/test/index.js
@@ -148,6 +148,9 @@ describe('.toAddress()', function () {
   it('should work with \'basic\'', function () {
     assert.equal(ICAP.toAddress('XE657SS84LEE90PIULMR3DYBGOVBNJN5N14'), '0x42c5496aee77c1ba1f0854206a26dda82a81d6d8')
   })
+  it('should work for \'long\'', function () {
+    assert.equal(ICAP.toAddress('XE870Z0SGY63X3UEPSSD6U9B3U9VIUOM1XP'), '0x08540829e2918aeb912b233b1e96366f075fe34d')
+  })
   it('shouldn\'t work with an asset', function () {
     assert.throws(function () {
       ICAP.toAddress('XE81ETHXREGGAVOFYORK')


### PR DESCRIPTION
When running a long ICAP address generated by jaxx.io

```
ICAP.isAddress('XE870Z0SGY63X3UEPSSD6U9B3U9VIUOM1XP')
```

we run into an infinite loop, causing

```
FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory
Abort trap: 6
```

This fixes the error, although I wasn't sure what to do about the leading zeroes in the resulting hex address. The code works for this particular address and should throw an error on stranger addresses.
